### PR TITLE
Blood glucose assertion and unit fix

### DIFF
--- a/android/src/main/kotlin/dev/duynp/flutter_health_connect/FlutterHealthConnectPlugin.kt
+++ b/android/src/main/kotlin/dev/duynp/flutter_health_connect/FlutterHealthConnectPlugin.kt
@@ -396,7 +396,7 @@ class FlutterHealthConnectPlugin(private var channel: MethodChannel? = null) : F
                         BLOOD_GLUCOSE -> BloodGlucoseRecord(
                             time = Instant.parse(recordMap["time"] as String),
                             zoneOffset = if (recordMap["zoneOffset"] != null) ZoneOffset.ofHours(recordMap["zoneOffset"] as Int) else null,
-                            level = BloodGlucose.millimolesPerLiter(recordMap["level"] as Double),
+                            level = BloodGlucose.milligramsPerDeciliter(recordMap["level"] as Double),
                             specimenSource = recordMap["specimenSource"] as Int,
                             mealType = recordMap["mealType"] as Int,
                             relationToMeal = recordMap["relationToMeal"] as Int,

--- a/lib/src/records/blood_glucose_record.dart
+++ b/lib/src/records/blood_glucose_record.dart
@@ -24,8 +24,8 @@ class BloodGlucoseRecord extends InstantaneousRecord {
       this.relationToMeal = RelationToMeal.unknown,
       this.mealType = MealType.unknown,
       metadata})
-      : assert(level.value <= _maxLevel.value),
-        assert(level.value >= _minLevel.value),
+      : assert(level.inMilligramsPerDeciliter <= _maxLevel.inMilligramsPerDeciliter),
+        assert(level.inMilligramsPerDeciliter >= _minLevel.inMilligramsPerDeciliter),
         metadata = metadata ?? Metadata.empty();
 
   static const BloodGlucose _maxLevel = BloodGlucose.millimolesPerLiter(50.0);


### PR DESCRIPTION
This PR fixes:

- Incorrect assertion if the unit is in mg/dl instead of mmol/l. Now the same unit values are compared.
- Incorrect value written because the unit in Dart is not matching the unit in Kotlin.