### PR TITLE
Add compatibility with AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+      namespace 'dev.duynp.flutter_health_connect'
+    }
+
     compileSdkVersion 34
 
     compileOptions {


### PR DESCRIPTION
The Android gradle plugin (AGP) in version 8 requires namespaces.
The solution was copied from the official cloud_firestore package and leads to a successful gradle sync.